### PR TITLE
deps: update pyo3-pack to latest for python 3.8 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -64,7 +64,10 @@ description = "Build and publish crates with pyo3, rust-cpython and cffi binding
 name = "pyo3-pack"
 optional = false
 python-versions = "*"
-version = "0.6.1"
+version = "0.7.0-beta.12"
+
+[package.dependencies]
+toml = ">=0.10.0,<0.11.0"
 
 [[package]]
 category = "dev"
@@ -115,6 +118,14 @@ version = "1.12.0"
 
 [[package]]
 category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.0"
+
+[[package]]
+category = "dev"
 description = "Fast, Extensible Progress Meter"
 name = "tqdm"
 optional = false
@@ -154,7 +165,7 @@ python-versions = "*"
 version = "0.5.1"
 
 [metadata]
-content-hash = "13b2763d9ea42870602b65858d4752fbb7f89c644c2ef562f5076ebefce052f8"
+content-hash = "22a550d74031592beca906b77dcf5ef25c41277a2daead76da697710ffba99ad"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -165,11 +176,12 @@ docutils = ["6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0", 
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
 pkginfo = ["7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb", "a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"]
 pygments = ["71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127", "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"]
-pyo3-pack = ["3b9b34ba43ad009c3b4ad3f508d0d364891f47242f47a604b4e5ea68dfcab32d", "61b8a7e1b2c83517e8ae59d9a3ec2819e9e78e42aedfb11bd2aa885a87d21464", "6360527be7a06e414542a9bb90db4f68beb24f774a3d5c0bcf8e1b729ef3e375", "d787a96f9927dab6e70e31a7c51778d4837504f96789fa7d87217c8da324d993", "e3804376cb5c2b51c49834539b0fb7373afbd142b7ff53846a011a01460e4c19"]
+pyo3-pack = ["05e7a9e3637cf0f4a0d931ed65f86b6e3cb44102ede0a6498558700dc7d8ed4a", "5d4adae64a7690e0e4526d70d5fd9ec0470ab333420225f856616e572b4b8a8a", "6ff1769e321315d6e6d9f26cd38450260cd1db0d8f12da94e6b86a09e4f6e229", "a2e0963c80150441da1eea4e385648cbb0ce0b725b461a1f8924db4c504d94ab", "a4857325dd5929910cdf40219e59a68f97948edbb39a0a382d9089b65d3463a3", "e6dbf367607150f6b75eb6f30acd650c424259834cf1443a4d13988c3614b22a"]
 readme-renderer = ["bb16f55b259f27f75f640acf5e00cf897845a8b3e4731b5c1a436e4b8529202f", "c8532b79afc0375a85f10433eca157d6b50f7d6990f337fa498c96cd4bfc203d"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
 requests-toolbelt = ["380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f", "968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
+toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"]
 tqdm = ["14a285392c32b6f8222ecfbcd217838f88e11630affe9006cd0e94c7eff3cb61", "25d4c0ea02a305a688e7e9c2cdc8f862f989ef2a4701ab28ee963295f5b109ab"]
 twine = ["0fb0bfa3df4f62076cab5def36b1a71a2e4acb4d1fa5c97475b048117b1a6446", "d6c29c933ecfc74e9b1d9fa13aa1f87c5d5770e119f5a4ce032092f0ff5b14dc"]
 urllib3 = ["b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1", "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Steve Dignam <steve@dignam.xyz>"]
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]
-pyo3-pack = "^0.6.1"
+pyo3-pack = "=0.7.0-beta.12"
 twine = "^1.13"
 
 [build-system]


### PR DESCRIPTION
Python 3.8 has some ABI changes which require a newer release of pyo3-pack.