### PR TITLE
Revert "fix: prevent crashing on GitLab's premium sections #20 (#21)"

### DIFF
--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -115,7 +115,7 @@ class CodeOwners:
     def __init__(self, text: str) -> None:
         paths: List[Tuple[Pattern[str], List[OwnerTuple]]] = []
         for line in text.splitlines():
-            if line == "" or line.startswith(("#", "^[", "[")):
+            if line == "" or line.startswith("#"):
                 continue
             elements = iter(line.split())
             path = next(elements, None)

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -39,21 +39,13 @@ EXAMPLE = """# This is a comment.
 # `docs/build-app/troubleshooting.md`.
 docs/*  docs@example.com
 
-# Let's test GitLab's premium feature of sections
-# see https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections
-[First team]
-
 # In this example, @octocat owns any file in an apps directory
 # anywhere in your repository.
 apps/ @octocat
 
-# Now, optional approval rule for GitLab's sections
-^[Second team]
-
 # In this example, @doctocat owns any file in the `/docs`
 # directory in the root of your repository.
 /docs/ @doctocat
-
 """
 
 


### PR DESCRIPTION
This reverts commit f33a257cf7ea808fe31b03eba75f6200ee27f1b7.

Turns out I really should have had CI run, this breaks patterns like `[abc]`