### PR TITLE
add: ignore gitlab's code owner sections

### DIFF
--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -115,7 +115,13 @@ class CodeOwners:
     def __init__(self, text: str) -> None:
         paths: List[Tuple[Pattern[str], List[OwnerTuple]]] = []
         for line in text.splitlines():
-            if line == "" or line.startswith("#"):
+            line = line.strip()
+            if (
+                line == ""
+                or line.startswith("#")
+                or (line.startswith("[") and line.endswith("]"))
+                or (line.startswith("^[") and line.endswith("]"))
+            ):
                 continue
             elements = iter(line.split())
             path = next(elements, None)

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -39,9 +39,20 @@ EXAMPLE = """# This is a comment.
 # `docs/build-app/troubleshooting.md`.
 docs/*  docs@example.com
 
+# Let's test GitLab's premium feature of sections
+# see https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections
+[First team]
+
+[Another team trailing whitespace] 
+
 # In this example, @octocat owns any file in an apps directory
 # anywhere in your repository.
 apps/ @octocat
+
+# Now, optional approval rule for GitLab's sections
+^[Second team]
+
+^[Second team trailing whitespace]   
 
 # In this example, @doctocat owns any file in the `/docs`
 # directory in the root of your repository.


### PR DESCRIPTION
Doesn't add support, but ignores gitlab's sections

related: https://github.com/sbdchd/codeowners/issues/20