### PR TITLE
whitespace handling and pattern return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 #**/*.rs.bk
 *.so
 dist
+codeowners/__pycache__/

--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -133,11 +133,15 @@ class CodeOwners:
                 owner_res = parse_owner(owner)
                 if owner_res is not None:
                     owners.append(owner_res)
-            paths.append((path_to_regex(path), path.replace(MASK, "\\ "), owners, line_num))
+            paths.append(
+                (path_to_regex(path), path.replace(MASK, "\\ "), owners, line_num)
+            )
         paths.reverse()
         self.paths = paths
 
-    def matching_line(self, filepath: str) -> Tuple[List[OwnerTuple], Optional[int], Optional[str]]:
+    def matching_line(
+        self, filepath: str
+    ) -> Tuple[List[OwnerTuple], Optional[int], Optional[str]]:
         for pattern, path, owners, line_num in self.paths:
             if pattern.search(filepath.replace(" ", MASK)) is not None:
                 return (owners, line_num, path)

--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -11,6 +11,7 @@ OwnerTuple = Tuple[Literal["USERNAME", "TEAM", "EMAIL"], str]
 TEAM = re.compile(r"^@\S+/\S+")
 USERNAME = re.compile(r"^@\S+")
 EMAIL = re.compile(r"^\S+@\S+")
+MASK = "/" * 20
 
 
 def path_to_regex(pattern: str) -> Pattern[str]:
@@ -113,7 +114,7 @@ def parse_owner(owner: str) -> Optional[OwnerTuple]:
 
 class CodeOwners:
     def __init__(self, text: str) -> None:
-        paths: List[Tuple[Pattern[str], List[OwnerTuple], int]] = []
+        paths: List[Tuple[Pattern[str], str, List[OwnerTuple], int]] = []
         for line_num, line in enumerate(text.splitlines(), start=1):
             line = line.strip()
             if (
@@ -123,7 +124,7 @@ class CodeOwners:
                 or (line.startswith("^[") and line.endswith("]"))
             ):
                 continue
-            elements = iter(line.split())
+            elements = iter(line.replace("\\ ", MASK).split())
             path = next(elements, None)
             if path is None:
                 continue
@@ -132,15 +133,15 @@ class CodeOwners:
                 owner_res = parse_owner(owner)
                 if owner_res is not None:
                     owners.append(owner_res)
-            paths.append((path_to_regex(path), owners, line_num))
+            paths.append((path_to_regex(path), path.replace(MASK, "\\ "), owners, line_num))
         paths.reverse()
         self.paths = paths
 
-    def matching_line(self, filepath: str) -> Tuple[List[OwnerTuple], Optional[int]]:
-        for pattern, owners, line_num in self.paths:
-            if pattern.search(filepath) is not None:
-                return (owners, line_num)
-        return ([], None)
+    def matching_line(self, filepath: str) -> Tuple[List[OwnerTuple], Optional[int], Optional[str]]:
+        for pattern, path, owners, line_num in self.paths:
+            if pattern.search(filepath.replace(" ", MASK)) is not None:
+                return (owners, line_num, path)
+        return ([], None, None)
 
     def of(self, filepath: str) -> List[OwnerTuple]:
         return self.matching_line(filepath)[0]

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -499,11 +499,7 @@ GO_CODEOWNER_EXAMPLES = [
     ex(
         name="spaces in file name",
         pattern="foo/b\\ ar.py",
-        paths={
-            "foo": False,
-            "foo/b ar.py": True,
-            "foo/bar.py": False,
-        },
+        paths={"foo": False, "foo/b ar.py": True, "foo/bar.py": False},
     ),
 ]
 

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -104,29 +104,34 @@ def test_github_example_matches(
 
 
 @pytest.mark.parametrize(
-    "path,expected_owners,expected_line_num",
+    "path,expected_path,expected_owners,expected_line_num",
     [
         (
+            "buzz/docs/gettingstarted.md",
             "buzz/docs/gettingstarted.md",
             [("USERNAME", "@global-owner1"), ("USERNAME", "@global-owner2")],
             8,
         ),
-        ("foo.js", [("USERNAME", "@js-owner")], 14),
+        ("foo.js", "foo.js", [("USERNAME", "@js-owner")], 14),
     ],
 )
 def test_github_example_matches_with_lines(
     path: str,
+    expected_path: str,
     expected_owners: List[Tuple[Literal["USERNAME", "EMAIL", "TEAM"], str]],
     expected_line_num: int,
 ) -> None:
     owners = CodeOwners(EXAMPLE)
-    actual_owners, actual_line_num = owners.matching_line(path)
+    actual_owners, actual_line_num, actual_path = owners.matching_line(path)
     assert (
         actual_owners == expected_owners
     ), f"mismatch for {path}, expected: {expected_owners}, got: {actual_owners}"
     assert (
         actual_line_num == expected_line_num
     ), f"mismatch for {path}, expected linenum: {expected_line_num}, got: {actual_line_num}"
+    assert (
+        actual_line_num == expected_line_num
+    ), f"mismatch for {path}, expected linenum: {expected_path}, got: {actual_path}"
 
 
 def test_rule_missing_owner() -> None:
@@ -477,6 +482,27 @@ GO_CODEOWNER_EXAMPLES = [
             "bar0.log": True,
             # differs between git versions
             # "bar[0-5].log": True,
+        },
+    ),
+    ex(
+        name="spaces in dir name",
+        pattern="foo/b\\ ar/",
+        paths={
+            "foo": False,
+            "foo/b ar": False,
+            "foo/b ar/": True,
+            "foo/b ar/baz": True,
+            "foo/b": False,
+            "foo/bar": False,
+        },
+    ),
+    ex(
+        name="spaces in file name",
+        pattern="foo/b\\ ar.py",
+        paths={
+            "foo": False,
+            "foo/b ar.py": True,
+            "foo/bar.py": False,
         },
     ),
 ]


### PR DESCRIPTION
# Description

This addresses https://github.com/sbdchd/codeowners/issues/34 and also updates `matching_line` method to return the path alongside the owners. This is very helpful for others who may want to parse the CODEOWNERS file but also need access to the path pattern.

Also updates `.gitignore` to ignore pycache

I am unsure how you want to handle the versioning for this, I imagine it should bump the minor version but will differ to you. Would you like me to do it in this PR or would you do it yourself?

# Testing

- [x] CI