### PR TITLE
Support gitlab sections

### DIFF
--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -150,7 +150,7 @@ class CodeOwners:
 
     def matching_lines(
         self, filepath: str
-    ) -> Generator[Tuple[List[OwnerTuple], Optional[int], Optional[str], Optional[str], Optional[str]], None, None]:
+    ) -> Generator[Tuple[List[OwnerTuple], Optional[int], Optional[str], Optional[str]], None, None]:
         for pattern, path, owners, line_num, section_name in self.paths:
             if pattern.search(filepath.replace(" ", MASK)) is not None:
                 yield (owners, line_num, path, section_name)

--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -116,7 +116,7 @@ class CodeOwners:
     def __init__(self, text: str) -> None:
         section_name = None
 
-        paths: List[Tuple[Pattern[str], str, List[OwnerTuple], int]] = []
+        paths: List[Tuple[Pattern[str], str, List[OwnerTuple], int, Optional[str]]] = []
         for line_num, line in enumerate(text.splitlines(), start=1):
             line = line.strip()
             if line == "" or line.startswith("#"):

--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -119,10 +119,7 @@ class CodeOwners:
         paths: List[Tuple[Pattern[str], str, List[OwnerTuple], int]] = []
         for line_num, line in enumerate(text.splitlines(), start=1):
             line = line.strip()
-            if (
-                line == ""
-                or line.startswith("#")
-            ):
+            if line == "" or line.startswith("#"):
                 continue
             # Track the GitLab section name (if used)
             # https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections
@@ -143,14 +140,22 @@ class CodeOwners:
                 if owner_res is not None:
                     owners.append(owner_res)
             paths.append(
-                (path_to_regex(path), path.replace(MASK, "\\ "), owners, line_num, section_name)
+                (
+                    path_to_regex(path),
+                    path.replace(MASK, "\\ "),
+                    owners,
+                    line_num,
+                    section_name,
+                )
             )
         paths.reverse()
         self.paths = paths
 
     def matching_lines(
         self, filepath: str
-    ) -> Generator[Tuple[List[OwnerTuple], Optional[int], Optional[str], Optional[str]], None, None]:
+    ) -> Generator[
+        Tuple[List[OwnerTuple], Optional[int], Optional[str], Optional[str]], None, None
+    ]:
         for pattern, path, owners, line_num, section_name in self.paths:
             if pattern.search(filepath.replace(" ", MASK)) is not None:
                 yield (owners, line_num, path, section_name)

--- a/codeowners/__init__.py
+++ b/codeowners/__init__.py
@@ -114,16 +114,25 @@ def parse_owner(owner: str) -> Optional[OwnerTuple]:
 
 class CodeOwners:
     def __init__(self, text: str) -> None:
+        section_name = None
+
         paths: List[Tuple[Pattern[str], str, List[OwnerTuple], int]] = []
         for line_num, line in enumerate(text.splitlines(), start=1):
             line = line.strip()
             if (
                 line == ""
                 or line.startswith("#")
-                or (line.startswith("[") and line.endswith("]"))
-                or (line.startswith("^[") and line.endswith("]"))
             ):
                 continue
+            # Track the GitLab section name (if used)
+            # https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections
+            elif line.startswith("[") and line.endswith("]"):
+                section_name = line[1:-1]
+                continue
+            elif line.startswith("^[") and line.endswith("]"):
+                section_name = line[2:-1]
+                continue
+
             elements = iter(line.replace("\\ ", MASK).split())
             path = next(elements, None)
             if path is None:
@@ -134,22 +143,31 @@ class CodeOwners:
                 if owner_res is not None:
                     owners.append(owner_res)
             paths.append(
-                (path_to_regex(path), path.replace(MASK, "\\ "), owners, line_num)
+                (path_to_regex(path), path.replace(MASK, "\\ "), owners, line_num, section_name)
             )
         paths.reverse()
         self.paths = paths
 
     def matching_lines(
         self, filepath: str
-    ) -> Generator[Tuple[List[OwnerTuple], Optional[int], Optional[str]], None, None]:
-        for pattern, path, owners, line_num in self.paths:
+    ) -> Generator[Tuple[List[OwnerTuple], Optional[int], Optional[str], Optional[str], Optional[str]], None, None]:
+        for pattern, path, owners, line_num, section_name in self.paths:
             if pattern.search(filepath.replace(" ", MASK)) is not None:
-                yield (owners, line_num, path)
+                yield (owners, line_num, path, section_name)
 
     def matching_line(
         self, filepath: str
-    ) -> Tuple[List[OwnerTuple], Optional[int], Optional[str]]:
-        return next(self.matching_lines(filepath), ([], None, None))
+    ) -> Tuple[List[OwnerTuple], Optional[int], Optional[str], Optional[str]]:
+        return next(self.matching_lines(filepath), ([], None, None, None))
+
+    def section_name(self, filepath: str) -> Optional[str]:
+        """
+        Find the section name of the specified file path.
+
+        None is returned when no matching section information
+        was found (or sections are not used in the CODEOWNERS file)
+        """
+        return self.matching_line(filepath)[3]
 
     def of(self, filepath: str) -> List[OwnerTuple]:
         return self.matching_line(filepath)[0]

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -109,11 +109,15 @@ def test_gitlab_sections():
     owners = CodeOwners(EXAMPLE)
     code_path = "build/logs/foo.go"
     actual_section_name = owners.section_name(code_path)
-    assert (actual_section_name == "Logs"), f"Expected section name of Logs for {code_path} got {actual_section_name}"
+    assert (
+        actual_section_name == "Logs"
+    ), f"Expected section name of Logs for {code_path} got {actual_section_name}"
 
     code_path = "foo/apps/foo.js"
     actual_section_name = owners.section_name(code_path)
-    assert (actual_section_name == "Another team trailing whitespace"), f"Expected section name of 'Another team trailing whitespace' for {code_path} got {actual_section_name}"
+    assert (
+        actual_section_name == "Another team trailing whitespace"
+    ), f"Expected section name of 'Another team trailing whitespace' for {code_path} got {actual_section_name}"
 
 
 @pytest.mark.parametrize(
@@ -135,8 +139,12 @@ def test_github_example_matches_with_lines(
     expected_line_num: int,
 ) -> None:
     owners = CodeOwners(EXAMPLE)
-    actual_owners, actual_line_num, actual_path, section_name = owners.matching_line(path)
-    assert section_name is None, f"section name should have been None but found {section_name}"
+    actual_owners, actual_line_num, actual_path, section_name = owners.matching_line(
+        path
+    )
+    assert (
+        section_name is None
+    ), f"section name should have been None but found {section_name}"
     assert (
         actual_owners == expected_owners
     ), f"mismatch for {path}, expected: {expected_owners}, got: {actual_owners}"

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -105,7 +105,7 @@ def test_github_example_matches(
     ), f"mismatch for {path}, expected: {expected}, got: {actual}"
 
 
-def test_gitlab_sections():
+def test_gitlab_sections() -> None:
     owners = CodeOwners(EXAMPLE)
     code_path = "build/logs/foo.go"
     actual_section_name = owners.section_name(code_path)

--- a/codeowners/test_codeowners.py
+++ b/codeowners/test_codeowners.py
@@ -32,11 +32,13 @@ EXAMPLE = """# This is a comment.
 # In this example, @doctocat owns any files in the build/logs
 # directory at the root of the repository and any of its
 # subdirectories.
+[Logs]
 /build/logs/ @doctocat
 
 # The `docs/*` pattern will match files like
 # `docs/getting-started.md` but not further nested files like
 # `docs/build-app/troubleshooting.md`.
+[Docs]
 docs/*  docs@example.com
 
 # Let's test GitLab's premium feature of sections
@@ -103,6 +105,17 @@ def test_github_example_matches(
     ), f"mismatch for {path}, expected: {expected}, got: {actual}"
 
 
+def test_gitlab_sections():
+    owners = CodeOwners(EXAMPLE)
+    code_path = "build/logs/foo.go"
+    actual_section_name = owners.section_name(code_path)
+    assert (actual_section_name == "Logs"), f"Expected section name of Logs for {code_path} got {actual_section_name}"
+
+    code_path = "foo/apps/foo.js"
+    actual_section_name = owners.section_name(code_path)
+    assert (actual_section_name == "Another team trailing whitespace"), f"Expected section name of 'Another team trailing whitespace' for {code_path} got {actual_section_name}"
+
+
 @pytest.mark.parametrize(
     "path,expected_path,expected_owners,expected_line_num",
     [
@@ -122,7 +135,8 @@ def test_github_example_matches_with_lines(
     expected_line_num: int,
 ) -> None:
     owners = CodeOwners(EXAMPLE)
-    actual_owners, actual_line_num, actual_path = owners.matching_line(path)
+    actual_owners, actual_line_num, actual_path, section_name = owners.matching_line(path)
+    assert section_name is None, f"section name should have been None but found {section_name}"
     assert (
         actual_owners == expected_owners
     ), f"mismatch for {path}, expected: {expected_owners}, got: {actual_owners}"


### PR DESCRIPTION
Hi!

This pull request is seeking to introduce support for determining the GitLab section name of a file based on a CODEOWNERS file. (When section names are used)

https://docs.gitlab.com/ee/user/project/code_owners.html#code-owners-sections

This builds on https://github.com/sbdchd/codeowners/pull/23 to ensure folks can easily get the section name in addition to determining if a file is owned based on CODEOWNERS without just ignoring the section name information.

For folks managing a large monorepo with CODEOWNERS on GitLab, the sections are a nice way to group code by "system name."   Exposing this information via the codeowners library is really valuable for folks that need to determine how much code/data is associated with each system living in that monorepo as well as how much code is owned vs. unowned.

Thanks!

Brian