### PR TITLE
Document that query paths must be repo-relative (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@ assert owners.of("test.js") ==  [('USERNAME', '@ghost')]
 
 ### Path format
 
-Paths passed to `of()` (and `matching_line()` / `section_name()`) must be
-repo-relative with no leading slash, matching the behavior of the upstream
-[Go](https://github.com/hmarr/codeowners/) and
-[Rust](https://github.com/hmarr/codeowners-rs) libraries as well as
-`git check-ignore`. A leading slash will not match:
+Paths must be repo-relative with no leading slash, matching `git check-ignore`. A leading
+slash will not match:
 
 ```python
 owners = CodeOwners("/build/logs/log.txt @ghost")

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ owners = CodeOwners(example_file)
 assert owners.of("test.js") ==  [('USERNAME', '@ghost')]
 ```
 
+### Path format
+
+Paths passed to `of()` (and `matching_line()` / `section_name()`) must be
+repo-relative with no leading slash, matching the behavior of the upstream
+[Go](https://github.com/hmarr/codeowners/) and
+[Rust](https://github.com/hmarr/codeowners-rs) libraries as well as
+`git check-ignore`. A leading slash will not match:
+
+```python
+owners = CodeOwners("/build/logs/log.txt @ghost")
+assert owners.of("build/logs/log.txt") == [('USERNAME', '@ghost')]  # ✅
+assert owners.of("/build/logs/log.txt") == []                       # ✗ leading slash
+```
+
 ## Dev
 
 ```shell


### PR DESCRIPTION
hmarr/codeowners and hmarr/codeowners-rs match our behavior.

Both expect repo-relative, no-leading-slash query paths, consistent with `git check-ignore`.

Closes #40.